### PR TITLE
build(deps): bump faraday and json version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,13 +2,13 @@ GEM
   remote: https://rubygems.org/
   specs:
     date (3.5.1)
-    faraday (2.14.0)
+    faraday (2.14.1)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
     faraday-net_http (3.4.2)
       net-http (~> 0.5)
-    json (2.18.0)
+    json (2.19.3)
     logger (1.7.0)
     mini_portile2 (2.8.9)
     net-http (0.9.1)


### PR DESCRIPTION
Bumps:

- [faraday](https://github.com/lostisland/faraday) from 2.14.0 to 2.14.1. [releases v2.14.1](https://github.com/lostisland/faraday/releases/tag/v2.14.1).
  Changelog: [https://github.com/lostisland/faraday/compare/v2.14.0...v2.14.1](https://github.com/lostisland/faraday/compare/v2.14.0...v2.14.1) (Sourced from [faraday's changelog](https://github.com/lostisland/faraday/blob/main/CHANGELOG.md)
- [json](https://github.com/ruby/json) from 2.18.0 to 2.19.3. [releases v2.19.3](https://github.com/ruby/json/releases/tag/v2.19.3).
  Changelog: [https://github.com/ruby/json/compare/v2.18.0...v2.19.3](https://github.com/ruby/json/compare/v2.18.0...v2.19.3) (Sourced from [json's changelog](https://github.com/ruby/json/blob/master/CHANGES.md))